### PR TITLE
Update printer.cfg

### DIFF
--- a/config/printer.cfg
+++ b/config/printer.cfg
@@ -407,7 +407,7 @@ shutdown_value:0
 value:0
 
 [smart_effector]
-pin:U_1:PC1
+pin:!PA10
 recovery_time:0
 x_offset: 25
 y_offset: 1.3
@@ -422,7 +422,7 @@ samples_tolerance: 0.05
 samples_tolerance_retries:5
 
 [qdprobe]
-pin:!PA10
+pin:U_1:PC1
 z_offset:0.000001
 
 [bed_mesh]


### PR DESCRIPTION
PINS of qdprobe and smart_effector are inverted.
Z offset works a lot better when they are switched.